### PR TITLE
Add support for 'elif'

### DIFF
--- a/src/nodes.co
+++ b/src/nodes.co
@@ -417,10 +417,27 @@ class NodeElseIf extends NodeTagContainer
         res += "#{@child_code opts, ctx}"
         return res
 
+class NodeElIf extends NodeTagContainer
+    @tag = \elif
+    @inside = elif: NodeElIf, else: NodeElse
+
+    (specs) ->
+        super ...
+
+    compile: function (opts, ctx)
+        if not trim @contents
+            throw new Error "{% elif <condition> %}: condition can't be empty."
+
+        res = "} else if (#{make_expression @contents, ctx}) {"
+        @ind opts
+        res += "#{@child_code opts, ctx}"
+        return res
+
+
 class NodeIf extends NodeTagContainer
     @tag = \if
     @until = \endif
-    @inside = else: NodeElse, elseif: NodeElseIf
+    @inside = else: NodeElse, elseif: NodeElseIf, elif: NodeElIf
 
     (specs) ->
         super ...

--- a/test/parser.co
+++ b/test/parser.co
@@ -105,9 +105,14 @@ suite.addBatch do
             res = _parse "{% if one == 2 %}TXT{% elseif one == 1 %}FO1{% elseif one == 3 %}FO3{% else %}FOO{% endif %}"
             equal res.txt, 'FO1'
 
+        "can have several elif clauses": ->
+            res = _parse "{% if one == 2 %}TXT{% elif one == 1 %}FO1{% elif one == 3 %}FO3{% else %}FOO{% endif %}"
+            equal res.txt, 'FO1'
+
         "can not be condition-less": ->
             throws (-> _parse "{% if %}TXT{% endif %}"), JinJSParseError
             throws (-> _parse "{% if one == 1 %}TXT{% elseif %}{% endif %}"), JinJSParseError
+            throws (-> _parse "{% if one == 1 %}TXT{% elif %}{% endif %}"), JinJSParseError
 
     ##
     ##  FOR TAG


### PR DESCRIPTION
While using https://github.com/ericclemmons/jinja.js, I ran into errors with some of my macros that contained code similar to:

{% if condition1 %}
A
{% elif condition2 %}
B
.
.
.
{% endif %}

Please consider adding these changes to support that jinja syntax.
